### PR TITLE
Fixing Navigation Files for Unity Tech Stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ Potential Topics--
         1. Set up
     9. Unity
         1. Introduction to Unity Basics
-        2. A Beginner's Guide for Unity UI Design 
+        2. How to Organize Unity Projects
+        3. A Beginner's Guide for Unity UI Design 
+        4. Unity ML Agents Tutorial
+        5. Unity 2D Top-down Character Controller Tutorial
     10. Python
         1. Pythonic iteration patterns
     11. Debugging in Python

--- a/Topics/Tech_Stacks.md
+++ b/Topics/Tech_Stacks.md
@@ -70,9 +70,15 @@
 
 ### [Asynchronous External API Interface in Python App](./Tech_Stacks/Async_External_API_Interface_Python.md)
 
-### [Introduction to Unity Basics](./Tech_Stacks/Unity_Intro.md)
+### [Introduction to Unity Basics](./Tech_Stacks/Unity/Unity_Intro.md)
 
-### [A Beginner's Guide for Unity UI Design](./Tech_Stacks/Unity_UI.md)
+### [How to Organize Unity Projects](./Tech_Stacks/Unity/Unity_Organization.md)
+
+### [A Beginner's Guide for Unity UI Design](./Tech_Stacks/Unity/Unity_UI.md)
+
+### [Unity ML Agents Tutorial](./Tech_Stacks/Unity/Unity_ML_Agents.md)
+
+### [Unity 2D Top-down Character Controller Tutorial](./Tech_Stacks/Unity/Unity_Tutorial_2D_TopDown_Character_Controller.md)
 
 ### [Learning JSON-RPC](./Tech_Stacks/JSONRPC.md)
 


### PR DESCRIPTION
Related to this PR: https://github.com/learning-software-engineering/learning-software-engineering.github.io/pull/429

Paridhi belatedly noticed that the Tech_Stacks.md links would be broken after I reorganized the Unity files into a new folder, so I fixed those, as well as added in the Unity files that were missing from the ReadMe and Tech_Stacks markdowns.